### PR TITLE
Add LGT8F328P Support

### DIFF
--- a/MemCARDuino.ino
+++ b/MemCARDuino.ino
@@ -76,6 +76,12 @@
   #define DataPin   50
   #define AttPin    53
   #define AckPin    2
+#elif defined (ARDUINO_AVR_LARDU_328E)
+  #define DataPin   12
+  #define CmndPin   11
+  #define AttPin    10
+  #define ClockPin  13
+  #define AckPin    2
 #else
   #define DataPin   12
   #define AttPin    10
@@ -97,7 +103,7 @@ void PinSetup()
   digitalWrite(AttPin, HIGH);
 
   //Set up SPI
-#if defined (ARDUINO_ARCH_RP2040) || (ESP8266) || (ESP32)
+#if defined (ARDUINO_ARCH_RP2040) || (ESP8266) || (ESP32) || (ARDUINO_AVR_LARDU_328E)
   pinMode(ClockPin, OUTPUT);
   pinMode(CmndPin, OUTPUT);
 
@@ -136,7 +142,7 @@ ICACHE_RAM_ATTR void ACK()
   state = !state;
 }
 
-#if defined (ARDUINO_ARCH_RP2040) || (ESP8266) || (ESP32)
+#if defined (ARDUINO_ARCH_RP2040) || (ESP8266) || (ESP32) || (ARDUINO_AVR_LARDU_328E)
 //Software SPI bit bang, turned out to be the most compatible with PocketStations
 byte SoftTransfer(byte data)
 {
@@ -172,7 +178,7 @@ byte SendCommand(byte CommandByte, int Timeout, int Delay)
     }
 
     //Send data on the SPI bus
-#if defined (ARDUINO_ARCH_RP2040) || (ESP8266) || (ESP32)
+#if defined (ARDUINO_ARCH_RP2040) || (ESP8266) || (ESP32) || (ARDUINO_AVR_LARDU_328E)
     byte data = SoftTransfer(CommandByte);
 #else
     byte data = SPI.transfer(CommandByte);

--- a/MemCARDuino.ino
+++ b/MemCARDuino.ino
@@ -166,7 +166,10 @@ byte SendCommand(byte CommandByte, int Timeout, int Delay)
     state = HIGH; //Set high state for ACK signal
 
     //Delay for a bit (values simulating delays between real PS1 and Memory Card)
-    delayMicroseconds(Delay);
+    if (Delay > 0) 
+    {
+      delayMicroseconds(Delay);
+    }
 
     //Send data on the SPI bus
 #if defined (ARDUINO_ARCH_RP2040) || (ESP8266) || (ESP32)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * Arduino Mega 2560
 * Espressif [ESP8266](https://github.com/esp8266/Arduino), [ESP32](https://github.com/espressif/arduino-esp32) (requires additional board URL)
 * [Raspberry Pi Pico](https://github.com/earlephilhower/arduino-pico) (requires additional board URL)
+* Logic Green [LGT8F328P](https://github.com/dbuezas/lgt8fx) (requires additional board URL)
 
 Various other boards can be supported if they have Arduino core available with SPI library with minimal or no editing to the sketch.
 


### PR DESCRIPTION
I've been tinkering with the MC Reader I showed you a bit ago, and I went ahead with replacing the stock ATmega-based module with a LGT8F328P (I just wanted to play with it at 32Mhz), not without finding some issues that I've addressed through these changes:

- 7e6c128e7a52d597dbe437ad75629cea0a6232d4: The `delayMilliseconds` implementation for lgt8fx boards is handled by [LaZsolt/delayMicroseconds](https://github.com/LaZsolt/delayMicroseconds) and on its [README file for lgt8fx](https://github.com/LaZsolt/delayMicroseconds/blob/master/for_LGT8F/readme.md) it states that you should avoid zero delay. There are some calls to `SendCommand` with zero delay, and those were making operations painfully slow. Just adding an `if` conditional did the trick to not execute it if there is no delay required.
- 113d1e83890e7918809900c8e42f0c9a106b0aa5: When using SPI the first card read always failed, and subsequent reads were working, but that was certainly an unexpected behavior. I tried to run it through `SoftTransfer` and it worked flawlessly right away!

Tested it with an original PS1 MC and a PicoMemcard. Also, the `ARDUINO_AVR_LARDU_328E` name was obtained from the [lgt8fx wiki](https://github.com/dbuezas/lgt8fx/wiki/Identifying-MCU-and-board-variants-using-preprocessor).

Just to note, after I made it work I noticed https://github.com/ShendoXT/memcarduino/issues/28 but I never had flashing issues (other than flashing them at 57600) or it not being detected as Memcarduino. They may have changed the bootloader, since my board looks identical to the one shown at the issue.

<details>
  <summary>Some pics</summary>
  
  Ali Board
![IMG_1477](https://github.com/user-attachments/assets/eb5b1967-ccfc-476a-afd1-82b6a5d938f2)
![IMG_1478](https://github.com/user-attachments/assets/960a2afb-5248-48d6-85b5-ef0dfb8ae7e3)

  Soldered LGT8F328P (some pins only as anchor points)
![IMG_1482](https://github.com/user-attachments/assets/61990610-2ffc-4ea5-a772-7a35afa910f2)



</details>